### PR TITLE
Fix TypeError in SHA1 padding attack code

### DIFF
--- a/sha.py
+++ b/sha.py
@@ -63,7 +63,7 @@ def _long2bytesBigEndian(n, blocksize=0):
 def _bytelist2longBigEndian(list):
     "Transform a list of characters into a list of longs."
 
-    imax = len(list)/4
+    imax = len(list) // 4
     hl = [0] * imax
 
     j = 0


### PR DESCRIPTION
Fix the TypeError caused by non-integer multiplication in `sha.py`.

* Change the `imax` calculation in the `_bytelist2longBigEndian` function to use integer division.
